### PR TITLE
Get Maven site generating and deploying as expected

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ projects to the Grader.
 Note that the `survey.sh` script **must be executed on one of the PSU MCECS Linux machines**.  It cannot be run on your
 laptop or local development machine.
 
-From the top-level directory of your, run the `survey.sh` script.  It will ask you to enter some information about
+From the top-level directory of your local repository, run the `survey.sh` script.  It will ask you to enter some information about
 yourself.  This information is used to submit your projects and record your grades.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -561,6 +561,7 @@ pushing it to GitHub:
 ```
 $ git checkout 62fc42c5b0cf4ddddf78e7568b008bedc9037b38
 $ git branch gh-pages
+$ git checkout gh-pages
 $ git rm README.md
 $ git commit -m "Remove README.md on gh-pages branch" README.md
 $ git push --set-upstream origin gh-pages

--- a/koans/pom.xml
+++ b/koans/pom.xml
@@ -2,9 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>cs410j</artifactId>
-    <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <groupId>edu.pdx.cs410J.whitlock</groupId>
+    <artifactId>PortlandStateJavaSummer2022</artifactId>
+    <version>2022.0.0</version>
   </parent>
   <groupId>edu.pdx.cs410J.whitlock</groupId>
   <artifactId>koans</artifactId>

--- a/koans/src/site/site.xml
+++ b/koans/src/site/site.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/phonebill/pom.xml
+++ b/phonebill/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
-    <artifactId>cs410j</artifactId>
-    <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <groupId>edu.pdx.cs410J.whitlock</groupId>
+    <artifactId>PortlandStateJavaSummer2022</artifactId>
+    <version>2022.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>edu.pdx.cs410J.whitlock</groupId>

--- a/phonebill/src/site/site.xml
+++ b/phonebill/src/site/site.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@ accordingly
   </repositories>
 
   <scm>
-    <connection>scm:git:http://YourGitHubUser/PortlandStateJavaSummer2022.git</connection>
+    <connection>scm:git:git@github.com:YourGithubUser/PortlandStateJavaSummer2022.git</connection>
   </scm>
   <distributionManagement>
     <snapshotRepository>
@@ -82,7 +82,7 @@ accordingly
     <site>
       <id>gh-pages</id>
       <name>GitHub Pages</name>
-      <url>scm:git:http://YourGitHubUser/PortlandStateJavaSummer2022.git</url>
+      <url>scm:git:git@github.com:YourGithubUser/PortlandStateJavaSummer2022.git</url>
     </site>
   </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ accordingly
   <packaging>pom</packaging>
   <name>PSUJavaSummer2022</name>
   <description>Source code written in the Summer 2022 offering of Advanced Programming with Java</description>
-  <url>http://YourGitHubUserInLowerCase.github.io/PortlandStateJavaSummer2022</url>
+  <url>http://davidwhitlock.github.io/PortlandStateJavaSummer2022</url>
 
   <modules>
     <module>student</module>
@@ -36,7 +36,7 @@ accordingly
   </organization>
   <issueManagement>
     <system>github</system>
-    <url>https://github.com/YourGitHubUser/PortlandStateJavaSummer2022/issues</url>
+    <url>https://github.com/DavidWhitlock/PortlandStateJavaSummer2022/issues</url>
   </issueManagement>
   <licenses>
     <license>
@@ -75,7 +75,7 @@ accordingly
   </repositories>
 
   <scm>
-    <connection>scm:git:git@github.com:YourGithubUser/PortlandStateJavaSummer2022.git</connection>
+    <connection>scm:git:git@github.com:DavidWhitlock/PortlandStateJavaSummer2022.git</connection>
   </scm>
   <distributionManagement>
     <snapshotRepository>
@@ -85,7 +85,7 @@ accordingly
     <site>
       <id>gh-pages</id>
       <name>GitHub Pages</name>
-      <url>scm:git:ssh://git@github.com/YourGithubUser/PortlandStateJavaSummer2022.git</url>
+      <url>scm:git:ssh://git@github.com/DavidWhitlock/PortlandStateJavaSummer2022.git</url>
     </site>
   </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@ accordingly
     <site>
       <id>gh-pages</id>
       <name>GitHub Pages</name>
-      <url>scm:git:git@github.com:YourGithubUser/PortlandStateJavaSummer2022.git</url>
+      <url>scm:git:ssh://git@github.com/YourGithubUser/PortlandStateJavaSummer2022.git</url>
     </site>
   </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,25 @@ accordingly
     </repository>
   </repositories>
 
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-site-plugin</artifactId>
+        <configuration>
+          <topSiteURL>scm:git:ssh://git@github.com/DavidWhitlock/PortlandStateJavaSummer2022.git</topSiteURL>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-scm-publish-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <scmBranch>gh-pages</scmBranch>
+          <tryUpdate>true</tryUpdate>
+          <addUniqueDirectory>true</addUniqueDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <scm>
     <connection>scm:git:git@github.com:DavidWhitlock/PortlandStateJavaSummer2022.git</connection>
   </scm>

--- a/student/src/site/site.xml
+++ b/student/src/site/site.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>


### PR DESCRIPTION
Between updating to the "fluido" site skin and using the `scm-publish` plugin to deploy to GitHub pages, there were some things that were broken about creating the Maven site.  
   * Add a `src/site/site.xml` to each of the child projects so that their site's `index.html` has links to interesting information
   * Configure the `maven-site-plugin` and `maven-scm-publish` plugins to deal with the fact that the parent project (my general "CS410J" project) has a different site URL.

These changes fix them, but I'm not planning on merging them in.

Instead, I'll make some of the changes on the upstream Getting Started repository and merge them into the Summer 2022 repository in class on Wednesday.

In the meantime, feel free to apply some of these changes to your own repository, if you want to get the site working before class on Wednesday.